### PR TITLE
Order the packages alphabetically in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pelican
 beautifulsoup4
+pelican
 requests


### PR DESCRIPTION
Listing them in alphabetical order is optimal for human readability, letting you quickly find if a package is present.

https://pip.pypa.io/en/latest/user_guide/#requirements-files

"Logically, a Requirements file is just a list of pip install arguments placed in a file. Note that you should not rely on the items in the file being installed by pip in any particular order."