### PR TITLE
Fix link and fix indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The team's website source will be developed here as well.
 
 ## How to contribute to the discussion
 
-- Via [GH Issues](../../issues)
+- Via [GH Issues](https://github.com/apache/tooling-docs/issues)
 - Email to dev@tooling.apache.org
 - ASF Slack Channels:
   - [#tooling-discuss](https://the-asf.slack.com/archives/C086X8CKEMB)

--- a/content/theme/templates/page.html
+++ b/content/theme/templates/page.html
@@ -11,7 +11,7 @@
   <body class="d-flex flex-column h-100">
     <main class="flex-shrink-0">
       <div>
-	{% include "menu.html" %}
+        {% include "menu.html" %}
         {% include "generic.html" %}
         {% include "footer.html" %}
       </div>


### PR DESCRIPTION
The issues link now works on your local machine in your IDE when viewing the README

Minor indent fix removed a tab to make the indentation consistent