### PR TITLE
pre-commit add spelling checking with crate `typos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
         args: [--strict, -c=.github/linters/.yaml-lint.yml]
         types: [yaml]
         files: \.ya?ml$
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.34.0
+    hooks:
+      - id: typos
+        files: \.(html|md|py|sh|ya?ml)$
+        args: [--config=.github/linters/.typos.toml]


### PR DESCRIPTION
I already fixed a lot of spelling in previous PRs using `typos` from the command line

https://github.com/crate-ci/typos

https://github.com/crate-ci/typos/blob/master/docs/pre-commit.md

In future we can customize more by adding info to the config file:

https://github.com/crate-ci/typos/blob/master/docs/reference.md