### PR TITLE
Create Makefile for more automation and convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+PYTHON ?= python3
+PIP := $(PYTHON) -m pip
+
+.PHONY: install i check c checkinstall ci checkupdate cu help
+.DEFAULT_GOAL := help
+
+install i: ## Install Python dependencies from requirements.txt
+	$(PIP) install -r requirements.txt
+
+check c: ## Run pre-commit checks on all files
+	pre-commit run --all-files
+
+checkinstall ci: ## Install pre-commit hooks
+	pre-commit install
+
+checkupdate cu: ## Update pre-commit hooks to the latest version
+	pre-commit autoupdate
+
+help: ## Display this help message
+	@echo "Usage: make <target>"
+	@echo
+	@echo "Available targets:"
+	@grep -E '^[a-z]+ [a-z]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
We can expand on this in future perhaps installing the pre-commit package and / or adding more targets

So we have #38 in play another "Python" PR and idea

So the image below is from my local machine showing make running and displaying the "help" default target:

<img width="1214" height="646" alt="Screenshot from 2025-07-25 16-46-15" src="https://github.com/user-attachments/assets/817da2f9-73ef-4dbb-8166-9324a15ce778" />
