### PR TITLE
Fix typo; `Github` -> `GitHub`

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -48,7 +48,7 @@ Here are the source code repositories. Please view the README.md files for instr
 
 1. Website: https://github.com/apache/tooling-trusted-release
 2. Python Client: https://github.com/apache/tooling-releases-client
-3. Github Actions: https://github.com/apache/tooling-actions
+3. GitHub Actions: https://github.com/apache/tooling-actions
 4. Example Workflows: https://github.com/apache/tooling-asf-example/
 
 ### Security Issues


### PR DESCRIPTION
Fixed the typo on content/pages/index.md