### PR TITLE
Add alt attribute to img tag in menu

### DIFF
--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -1,7 +1,7 @@
 <!-- nav bar -->
 <nav class="navbar navbar-expand-lg navbar-dark bg-info" aria-label="Fifth navbar example">
   <div class="container-fluid">
-    <a class="navbar-brand" href="/"><img src="https://apache.org/img/asf_logo.png" style="height: 42px;"/>
+    <a class="navbar-brand" href="/"><img src="https://apache.org/img/asf_logo.png" alt="The Apache Software Foundation" style="height: 42px;"/>
       <span style="position: relative; top: 5px; margin-left: 16px;">Tooling Initiative</span></a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarADP" aria-controls="navbarADP" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
You should have an alt attribute to make websites accessible for screen readers, display information when images fail to load, and improve SEO by helping search engines understand your images. 

https://en.wikipedia.org/wiki/Alt_attribute