### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,16 +1,16 @@
 staging:
-  profile: ~
+  profile:
   autostage: preview/*
 
 pelican:
-  notify:         commits@tooling.apache.org
-  autobuild:      preview/*
-  target:         asf-site
-  whoami:         main
+  notify: commits@tooling.apache.org
+  autobuild: preview/*
+  target: asf-site
+  whoami: main
 
 github:
-  description:   "ASF Tooling Team Documentation Repository"
-  homepage:      https://tooling.apache.org/
+  description: "ASF Tooling Team Documentation Repository"
+  homepage: https://tooling.apache.org/
   custom_subjects:
     new_pr: "[PR] {title} ({repository})"
     close_pr: "Re: [PR] {title} ({repository})"
@@ -25,7 +25,20 @@ github:
     - website
     - pelican
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@tooling.apache.org
-  issues:       dev@tooling.apache.org
+  commits: commits@tooling.apache.org
+  issues: dev@tooling.apache.org
   pullrequests: dev@tooling.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
