### PR TITLE
Update `.markdown-lint.yml` with comment linking to the rules

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,3 +1,5 @@
+# https://github.com/davidanson/markdownlint#rules--aliases
+
 MD003:
   style: atx
 


### PR DESCRIPTION
Added a comment with a link to markdownlint rules.